### PR TITLE
Use fern-api/setup-fern-cli@v1 in publish-docs workflow

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -11,8 +11,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Fern
-        run: npm install -g fern-api
+      - name: Setup Fern CLI
+        uses: fern-api/setup-fern-cli@v1
 
       - name: Generate preview URL
         id: generate-docs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Fern
-        run: npm install -g fern-api
+      - name: Setup Fern CLI
+        uses: fern-api/setup-fern-cli@v1
 
       - name: Publish Docs
         env:


### PR DESCRIPTION
## Summary

- Replaces the `npm install -g fern-api` run step with the `fern-api/setup-fern-cli@v1` GitHub Action in `.github/workflows/publish-docs.yml`
- No `setup-node` step is needed since GitHub-hosted `ubuntu-latest` runners include Node.js by default

## Test plan

- [ ] Verify the `publish-docs` workflow runs successfully after merging
- [ ] Confirm the Fern CLI is installed correctly via the action and `fern generate --docs` completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)